### PR TITLE
ci: 🐝 update dprint config and move to GitHub action from pre-commit hook

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Enforce formatting
         run: cargo fmt --check
 
+  fmt-dprint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dprint/check@v2.2
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,10 +11,6 @@ repos:
   - id: clippy
   repo: https://github.com/doublify/pre-commit-rust
   rev: v1.0
-#- repo: https://github.com/adamchainz/pre-commit-dprint
-#  rev: v0.36.0
-#  hooks:
-#  -   id: dprint
 - repo: https://github.com/gitleaks/gitleaks
   rev: v8.17.0
   hooks:

--- a/dprint.json
+++ b/dprint.json
@@ -7,11 +7,12 @@
   },
   "includes": ["**/*.{json,md,toml}"],
   "excludes": [
-    "**/*-lock.json"
+    "**/*-lock.json",
+    "target"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/json-0.17.1.wasm",
-    "https://plugins.dprint.dev/markdown-0.15.2.wasm",
+    "https://plugins.dprint.dev/json-0.17.4.wasm",
+    "https://plugins.dprint.dev/markdown-0.15.3.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm"
   ]
 }


### PR DESCRIPTION
# Description

Update dprint conifg, removing the dprint pre-commit hook, which is no longer supported, and replacing it with a GitHub action.  Also update dpring plugins.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
